### PR TITLE
Feat: [1912] 연속합 문제 + [1699] 제곱수의 합 풀이

### DIFF
--- a/Semi/백준/[1699]제곱수의 합.py
+++ b/Semi/백준/[1699]제곱수의 합.py
@@ -1,0 +1,38 @@
+'''
+Author    : semi
+Date      : 2025.04.12(Sat)
+Runtime   : 7196ms
+Memory    : 33192KB
+Algorithm : Dynamic Programming
+'''
+
+# approach #1
+# Greedy한방식 : 가장 큰 제곱수 부터 가능한 한 최대한 많이 쓰고 나머지를 채우는 방식
+# ex) 11 -> 가장 큰 제곱 수 9 -> 11 = 9 =2 -> 11 = 3^2 + 1^2 + 1^2 
+# Problem : 항상 최소를 보장하지 않는다. ex) 12 
+
+
+# approach #2
+# Dynamic Programming
+n = int(input())
+
+#dp : i를 제곱수의 합으로 나타내는 필요한한 '최소' 항의 개수를 저장
+# 초기값 : 무한대로 설정
+dp = [float('inf')]*(n+1)
+# 0을 표현하는데 필요한 항 = 0개
+dp[0] = 0
+
+
+#dp 배열 채우기 (bottom-up)
+for i in range(1,n+1):
+    j = 1
+    while j*j <= i:
+        dp[i] = min(dp[i],dp[i-j*j]+1)
+        # print(f"i ={i}, j={j}")
+        # print(f"dp[{i}]={dp[i]}")
+        j +=1
+
+print(dp[n])
+        
+        
+    

--- a/Semi/백준/[1912]연속합#1.py
+++ b/Semi/백준/[1912]연속합#1.py
@@ -1,0 +1,18 @@
+'''
+Author    : semi
+Date      : 2025.04.13(Sun)
+Runtime   : TLE
+Memory    : TLE
+Algorithm : Brute-force
+'''
+
+n = int(input())
+nl = list(map(int,input().split()))
+
+max_sum = float('-inf')
+for i in range(n):
+    for j in range(i,n):
+        current_sum = sum(nl[i:j+1])
+        max_sum = max(max_sum,current_sum)
+        
+print(max_sum)

--- a/Semi/백준/[1912]연속합#2.py
+++ b/Semi/백준/[1912]연속합#2.py
@@ -1,0 +1,19 @@
+'''
+Author    : semi
+Date      : 2025.04.13(Sun)
+Runtime   : 39096ms
+Memory    : 84KB
+Algorithm : Kadane's Algorithm
+'''
+
+n = int(input())
+nl = list(map(int,input().split()))
+
+max_sum= current_sum = nl[0]
+
+for i in range(1,n):
+    current_sum = max(nl[i],current_sum+nl[i])
+    max_sum = max(max_sum,current_sum)
+    
+print(max_sum)
+


### PR DESCRIPTION
## [1699] 제곱수의 합
### 처음 접근 방법

1. greedy 방법
- 틀린 이유
    - 항상 최소를 보장하지 않는다.
    - **그리디 방식**:
        - 3^2 = 9 → 12 - 9 = 3 → 1^2 세 번 → 총 **4개 항**
    - **최소 정답**은?
        - 4 + 4 + 4 = 12 → 2^2 세 번 → **3개 항**
    
2. Dynamic Programming
    
    ```java
    dp[i] = min(dp[i - j^2*] + 1)  #* j는 i보다 작거나 같은 제곱수
    ```
    

### 동적 계획법(Dynamic Programming, DP) 접근 이유

- **문제 분할**
    큰 문제를 작은 문제로 쪼갤 수 있다
    
- **부분 문제 중복**
    동일한 수를 만드는 경우가 여러 번 등장→ 이미 계산한 결과를 재활용할 수 있다.
    
- **최적화**
    각 단계에서 최소 항의 개수를 구해나가므로, 작은 문제의 최적해를 모아 큰 문제의 최적해를 보장

### 왜 작은 문제로 쪼갤 수 있는가?

1. 수 표현 분해 가능성
    - N = 제곱수들의 합
    - 한 번에 하나의 제곱수, j^2를 사용하면 N은 다음과 같이 표현할 수 있다.
        
        ```java
        N = j^2 + (N - j^2)
        ```
        
        - **→ N을 만드는 문제를 "j²를 한 번 사용하고, 남은 값을 만드는 문제"로 분리할 수 있다**
        - ex) 12를 제곱수의 합으로 표현
            - 문제 분해 아이디어 → 한 번 제곱수 하나를 사용 + 그 나머지 남은 값을 만든다.
                1. 제곱수 j^2 중 하나를 선택한다. (j^2 ≤ 12) → j^2 = 4 선택
                2. 12 - 4 = 8 
                
                → 12를 만드는 문제 = 4(제곱수)와 8(나머지)을 만드는 문제
                
                → 8 → **8을 만드는 최소 항의 개수로 쪼갤 수 있다.**


## [1912] 연속합 
### Kadane’s Algorithm
- 연속된 부분 수열 중 가장 큰 합을 구하는 알고리즘
- 시간 복잡도 O(n)
- 이전 인덱스가 갖고 있는 최대 부분합을 연장할지/ 자신의 값으로 초기화할지 선택 `dp[i] = max(nl[i], dp[i-1] + nl[i])`
![image](https://github.com/user-attachments/assets/a467be84-0eeb-4028-96f0-f646c6470e10)

[이미지 출처](https://medium.com/@vdongbin/kadanes-algorithm-%EC%B9%B4%EB%8D%B0%EC%9D%B8-%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-acbc8c279f29)