### PR TITLE
11주차 danny 문제풀이

### DIFF
--- a/Danny/백준/week11/[13460] 구슬 탈출 2.py
+++ b/Danny/백준/week11/[13460] 구슬 탈출 2.py
@@ -1,0 +1,65 @@
+import sys
+from collections import deque
+
+input = sys.stdin.readline
+
+N, M = map(int, input().split())
+li = [list(input().strip()) for _ in range(N)]
+
+dx = [0, 0, 1, -1]
+dy = [1, -1, 0, 0]
+
+visited = set()
+
+for i in range(N):
+    for j in range(M):
+        if li[i][j] == 'R':
+            rx, ry = i, j
+        elif li[i][j] == 'B':
+            bx, by = i, j
+
+def move(x, y, dx, dy):
+    dist = 0
+    while li[x + dx][y + dy] != '#' and li[x][y] != 'O':
+        x += dx
+        y += dy
+        dist += 1
+    return x, y, dist
+
+
+q = deque()
+q.append((rx, ry, bx, by, 0))
+visited.add((rx, ry, bx, by))
+
+while q:
+    rx, ry, bx, by, depth = q.popleft()
+    if depth >= 10:
+        break
+
+    for i in range(4):
+        nrx, nry, r_dist = move(rx, ry, dx[i], dy[i])
+        nbx, nby, b_dist = move(bx, by, dx[i], dy[i])
+
+        # 파란 구슬이 구멍에 빠질 경우
+        if li[nbx][nby] == 'O':
+            continue
+
+        # 빨간 구슬만 구멍에 빠졌을 경우
+        if li[nrx][nry] == 'O':
+            print(depth + 1)
+            exit()
+
+        # 두 구슬이 같은 위치에 있다면 거리 더 긴 쪽을 한 칸 뒤로
+        if nrx == nbx and nry == nby:
+            if r_dist > b_dist:
+                nrx -= dx[i]
+                nry -= dy[i]
+            else:
+                nbx -= dx[i]
+                nby -= dy[i]
+
+        if (nrx, nry, nbx, nby) not in visited:
+            visited.add((nrx, nry, nbx, nby))
+            q.append((nrx, nry, nbx, nby, depth + 1))
+
+print(-1)

--- a/Danny/백준/week11/[1389] 케빈 베이컨의 6단계 법칙.py
+++ b/Danny/백준/week11/[1389] 케빈 베이컨의 6단계 법칙.py
@@ -1,0 +1,45 @@
+import sys
+
+input = sys.stdin.readline
+
+N, M = map(int, input().split())
+
+li = [[] for _ in range(N+1)]
+
+# 인접 리스트 생성
+for i in range(M):
+    A, B = map(int, input().split())
+    li[A].append(B)
+    li[B].append(A)
+
+for i in range(N+1):
+  li[i] = list(set(li[i]))
+
+from collections import deque
+# 사람마다 BFS 진행
+def bfs(start):
+    visit = [-1] * (N+1)
+    visit[start] = 0
+    q = deque()
+    q.append(start)
+
+    while q:
+      now = q.popleft()
+      for i in li[now]:
+         if visit[i] == -1:
+            visit[i] = visit[now] + 1
+            q.append(i)
+    
+    return sum(visit[1:])
+
+# 최소값을 가지는 번호 계산
+min_value = 1e9
+answer = 0
+
+for i in range(1, N+1):
+    tmp = bfs(i)
+    if tmp < min_value:
+        min_value = tmp
+        answer = i
+
+print(answer)

--- a/Danny/백준/week11/[1520] 내리막길.py
+++ b/Danny/백준/week11/[1520] 내리막길.py
@@ -1,0 +1,32 @@
+import sys
+sys.setrecursionlimit(10**7)
+
+input = sys.stdin.readline
+
+N, M = map(int, input().split())
+
+li = [list(map(int, input().split()))for _ in range(N)]
+dp = [[-1] * M for _ in range(N)]
+
+
+dx = [0, 1, -1, 0]
+dy = [1, 0, 0, -1]
+
+def dfs(y, x):
+    if y == N-1 and x == M-1:
+        return 1
+    
+    if dp[y][x] != -1:
+        return dp[y][x] 
+
+    dp[y][x] = 0
+
+    for i in range(4):
+        nx=x+dx[i]
+        ny=y+dy[i]
+        if 0<=ny<N and 0<=nx<M:
+            if li[ny][nx] < li[y][x]:
+                dp[y][x] += dfs(ny, nx)
+    return dp[y][x]
+
+print(dfs(0,0))

--- a/Danny/백준/week11/[9205] 맥주 마시면서 걸어가기.py
+++ b/Danny/백준/week11/[9205] 맥주 마시면서 걸어가기.py
@@ -1,0 +1,40 @@
+import sys
+from collections import deque
+
+input = sys.stdin.readline
+
+t = int(input())
+
+def bfs(x, y):
+    q = deque()
+    q.append((x,y))
+    visit = [-1] * n
+
+    while q:
+        x, y = q.popleft()
+
+        if abs(rx- x) + abs(ry - y) <= 1000:
+            return "happy"
+        for i in range(n):
+            if visit[i] == -1:
+                nx, ny = p_li[i]
+                if abs(nx -x) + abs(ny-y) <= 1000:
+                    visit[i] = 1
+                    q.append((nx, ny))
+    return "sad"
+
+for i in range(t):
+    # 편의점의 개수 n
+    n = int(input())
+    
+    # 상근이네 집 좌표
+    sx, sy = map(int, input().split())
+    
+    # 편의점 좌표
+    p_li = [list(map(int, input().split())) for _ in range(n)]
+    
+    # 락 페스티벌 좌표
+    rx, ry = map(int, input().split())
+
+    print(bfs(sx, sy))
+    


### PR DESCRIPTION
- [X] <b>케빈 베이컨 6단계 법칙</b>

>N ≤ 100, M ≤ 5000 고려했을 때 모든 사람에 대해 bfs 실행해도 충분히 가능
  인접 리스트를 먼저 만들고
  이 인접리스트를 기반으로 bfs를 진행
  1번 사람부터 N번 사람까지 모든 사람에 대해 반복
  각 사람으로부터 다른 모든 사람까지의 최단거리를 BFS로 계산 후 합 구하기
  케빈 베이컨 수 합계 중 최소값을 찾기
  최소값을 가진 사람이 여러 명이면 번호가 가장 작은 사람을 출력

- [X] <b>내리막 </b>

> 모든 가능한 경로를 탐색해야 하므로 DFS 사용
  하지만 단순 DFS는 중복 탐색이 많아 시간 초과 발생  → DP를 함께 사용하자
  (0,0)에서 시작해 내리막길만 따라 이동
  dp[y][x]는 해당 위치에서 도착지까지 갈 수 있는 경로의 수
  이미 dp[y][x]가 계산되었으면 다시 DFS 호출하지 않고 재사용
  결국 중복 경로 계산을 방지하며 모든 유효 경로의 수를 계산할 수 있음


- [X] <b>맥주 마시면서 걸어가기</b>

>그냥 bfs 쓰면 풀 수 있을 것 같음
  편의점 개수와 테스트 케이스도 크지 않아서 신경쓰지 않아도 될듯함
  상근이네 집 좌표를 기준으로 계속 페스티벌 좌표로 갈 수 있는지 판별
  못가면 주변에 갈 수 있는 편의점 탐색 후 편의점을 기준으로 bfs 다시 진행
  방문한 편의점은 visit배열로 표시
  다 돌때까지 페스티벌에 가지 못하면 'sad'출력


- [X] <b>구슬 탈출 2</b>

> 파란공 빨간공 위치를 미리 저장
  한칸씩 가는게 아니라 기울여서 벽이나 구멍에 빠질 때까지 굴러가는 거니까 move함수를 통해 이동 구현
  벽바로 앞이거나 구멍에 빠지면 좌표 반환
  bfs는 진행 될 때마다 depth 카운트 같이
  depth가 10보다 커지면 -1 출력
  파란공이 먼저 구멍에 빠졌는지 판단 구멍에 빠졌으면 무시하고 다음 bfs 진행
  파란공이 안빠지고 빨간공이 빠졌으면 성공 depth반환
  둘이 겹칠 경우 부분은 공의 이동거리를 통해 더 멀리서 온 공이 늦게 도착하니깐 더 먼 공이 한칸 뒤로 위치
  이동한 빨강 파랑 depth를 인자로 bfs 계속 진행


